### PR TITLE
Add AI-based scraper extension

### DIFF
--- a/ai_scraper/background.js
+++ b/ai_scraper/background.js
@@ -1,0 +1,16 @@
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.action === 'aiScrape') {
+    fetch('http://localhost:11434/api/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'llama3',
+        prompt: `Extract structured data from this HTML and return JSON:\n${msg.html}`
+      })
+    })
+      .then(res => res.json())
+      .then(data => sendResponse({ result: data.response || data } ))
+      .catch(err => sendResponse({ error: err.toString() }));
+    return true; // keep port open for async response
+  }
+});

--- a/ai_scraper/content.js
+++ b/ai_scraper/content.js
@@ -1,0 +1,5 @@
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.action === 'getHTML') {
+    sendResponse({ html: document.documentElement.outerHTML });
+  }
+});

--- a/ai_scraper/manifest.json
+++ b/ai_scraper/manifest.json
@@ -1,0 +1,17 @@
+{
+  "manifest_version": 3,
+  "name": "AI Web Scraper",
+  "description": "Use AI to figure out how to scrape the current page.",
+  "version": "0.1",
+  "permissions": ["scripting", "activeTab"],
+  "host_permissions": ["<all_urls>"],
+  "background": { "service_worker": "background.js" },
+  "action": { "default_popup": "popup.html", "default_title": "AI Scraper" },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_end"
+    }
+  ]
+}

--- a/ai_scraper/popup.html
+++ b/ai_scraper/popup.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>AI Scraper</title>
+  <style>
+    body { font-family: Arial, sans-serif; width: 300px; }
+    button { margin: 10px 0; }
+    textarea { width: 100%; height: 150px; }
+  </style>
+</head>
+<body>
+  <button id="scrapeBtn">AI Scrape Current Page</button>
+  <pre id="result"></pre>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/ai_scraper/popup.js
+++ b/ai_scraper/popup.js
@@ -1,0 +1,22 @@
+function display(text) {
+  document.getElementById('result').innerText = text;
+}
+
+document.getElementById('scrapeBtn').addEventListener('click', () => {
+  chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+    if (!tabs[0]) return;
+    chrome.tabs.sendMessage(tabs[0].id, { action: 'getHTML' }, response => {
+      if (!response || !response.html) {
+        display('Could not get page HTML');
+        return;
+      }
+      chrome.runtime.sendMessage({ action: 'aiScrape', html: response.html }, res => {
+        if (res.error) {
+          display('Error: ' + res.error);
+        } else {
+          display(typeof res.result === 'string' ? res.result : JSON.stringify(res.result, null, 2));
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add new `ai_scraper` extension folder
- extension retrieves HTML from the active tab and sends it to a local LLM server
- display the AI's output in the popup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888ec5dd04083328b014698646fb711