### PR TITLE
feat: add multipage scraper extension

### DIFF
--- a/multipage_scraper/background.js
+++ b/multipage_scraper/background.js
@@ -1,0 +1,29 @@
+// Handle background scraping and persist state
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === 'startScrape') {
+    chrome.storage.local.set({ status: 'Scraping...', results: [] });
+    chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+      if (!tabs[0]) {
+        chrome.storage.local.set({ status: 'Error: No active tab' });
+        return;
+      }
+      chrome.tabs.sendMessage(
+        tabs[0].id,
+        { action: 'scrape', site: message.site },
+        response => {
+          if (chrome.runtime.lastError || !response) {
+            chrome.storage.local.set({ status: 'Error: Could not scrape on this page.', results: [] });
+          } else {
+            chrome.storage.local.set({ status: `Found ${response.data.length} results.`, results: response.data });
+          }
+        }
+      );
+    });
+    sendResponse({ started: true });
+    return true; // keep message channel open for async response
+  } else if (message.type === 'progress') {
+    chrome.storage.local.set({ status: `Scraping page ${message.page} — ${message.current} of ${message.total}: ${message.name}` });
+  } else if (message.type === 'partial') {
+    chrome.storage.local.set({ results: message.results });
+  }
+});

--- a/multipage_scraper/content.js
+++ b/multipage_scraper/content.js
@@ -1,0 +1,295 @@
+// Content script for multipage scraper supporting Yelp, Yellow Pages and Google Maps
+
+// ---- helpers ----
+const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+const jitter = (min, max) => min + Math.floor(Math.random() * (max - min + 1));
+
+// -------------------- YELP --------------------
+function yelpGetCards() {
+  return Array.from(document.querySelectorAll('div[data-testid="scrollable-photos-card"]'));
+}
+function yelpFirstResultName() {
+  const firstCard = yelpGetCards()[0];
+  const link = firstCard?.querySelector('div[data-traffic-crawl-id="SearchResultBizName"] a');
+  return (link?.textContent || "").trim();
+}
+async function yelpWaitForNewResults(prevUrl, prevFirst, timeoutMs = 20000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (location.href !== prevUrl) return true;
+    const nowFirst = yelpFirstResultName();
+    if (nowFirst && nowFirst !== prevFirst) return true;
+    await sleep(250);
+  }
+  return false;
+}
+function yelpFindNextButton() {
+  let btn = document.querySelector('button[aria-label="Next page"]');
+  if (btn) return btn;
+  const candidates = Array.from(document.querySelectorAll('button, a[role="button"]'));
+  btn = candidates.find(b => {
+    const t = (b.textContent || "").trim().toLowerCase();
+    return t === "next" || t === "next page";
+  });
+  return btn || null;
+}
+function yelpFindNextAnchor() {
+  return (
+    document.querySelector('a[rel="next"]') ||
+    document.querySelector('a[aria-label="Next"], a[aria-label="Next page"]') ||
+    null
+  );
+}
+function yelpSynthesizeNextUrl() {
+  try {
+    const url = new URL(location.href);
+    const currentStart = parseInt(url.searchParams.get("start") || "0", 10) || 0;
+    const perPage = Math.max(yelpGetCards().length, 10);
+    const nextStart = currentStart + perPage;
+    url.searchParams.set("start", String(nextStart));
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+async function yelpGetPhoneNumber(profileUrl) {
+  await sleep(jitter(120, 420));
+  try {
+    const response = await fetch(profileUrl, { credentials: "include" });
+    const text = await response.text();
+    const doc = new DOMParser().parseFromString(text, "text/html");
+    let phone =
+      doc.querySelector('a[href^="tel:"]')?.getAttribute("href")?.replace(/^tel:/, "").trim() || "";
+    if (!phone) {
+      phone =
+        doc
+          .querySelector('span[aria-label="Business phone number"]')
+          ?.parentElement?.nextElementSibling?.querySelector('p[data-font-weight="semibold"]')
+          ?.innerText.trim() || "";
+    }
+    return phone;
+  } catch {
+    return "";
+  }
+}
+function yelpScrapePageOnce() {
+  const out = [];
+  for (const card of yelpGetCards()) {
+    const bizLink = card.querySelector('div[data-traffic-crawl-id="SearchResultBizName"] a');
+    const href = bizLink?.getAttribute("href") || "";
+    if (!href.startsWith("/biz/")) continue;
+    const name = (bizLink?.innerText || "").trim();
+    const profileUrl = `https://www.yelp.com${href}`;
+    let categories = "";
+    const categoriesDiv = card.querySelector('div[data-testid="serp-ia-categories"]');
+    if (categoriesDiv) {
+      const categoryList = Array.from(categoriesDiv.querySelectorAll('a > button > span'))
+        .map(s => s.innerText.trim())
+        .filter(Boolean);
+      categories = categoryList.join(", ");
+    }
+    if (name) out.push({ name, profileUrl, categories });
+  }
+  return out;
+}
+async function yelpGotoNextPage() {
+  const btn = yelpFindNextButton();
+  if (btn) {
+    btn.scrollIntoView({ behavior: "smooth", block: "center" });
+    await sleep(jitter(350, 900));
+    btn.click();
+    return true;
+  }
+  const a = yelpFindNextAnchor();
+  if (a) {
+    a.scrollIntoView({ behavior: "smooth", block: "center" });
+    await sleep(jitter(350, 900));
+    a.click();
+    return true;
+  }
+  const nextUrl = yelpSynthesizeNextUrl();
+  if (nextUrl) {
+    window.scrollTo({ top: 0, behavior: "instant" });
+    await sleep(jitter(200, 500));
+    location.href = nextUrl;
+    return true;
+  }
+  return false;
+}
+async function scrapeYelp() {
+  let currentPage = 1;
+  let allResults = [];
+  const seenThisSession = new Set();
+  let stagnantStrike = 0;
+  while (true) {
+    const prevUrl = location.href;
+    const prevFirst = yelpFirstResultName();
+    const pageResults = yelpScrapePageOnce();
+    const pageKey = `${prevUrl}|${pageResults.map(r => r.profileUrl).join(",")}`;
+    if (seenThisSession.has(pageKey)) {
+      stagnantStrike++;
+    } else {
+      stagnantStrike = 0;
+      seenThisSession.add(pageKey);
+    }
+    for (let i = 0; i < pageResults.length; i++) {
+      const biz = pageResults[i];
+      biz.phone = await yelpGetPhoneNumber(biz.profileUrl);
+      chrome.runtime.sendMessage({
+        type: "progress",
+        current: i + 1,
+        total: pageResults.length,
+        name: biz.name,
+        page: currentPage
+      });
+      await sleep(jitter(260, 780));
+    }
+    const before = allResults.length;
+    const have = new Set(allResults.map(r => r.profileUrl));
+    for (const r of pageResults) {
+      if (!have.has(r.profileUrl)) {
+        allResults.push(r);
+        have.add(r.profileUrl);
+      }
+    }
+    chrome.runtime.sendMessage({ type: "partial", results: allResults });
+    const added = allResults.length - before;
+    if (added === 0 || stagnantStrike >= 2) {
+      const tried = await yelpGotoNextPage();
+      if (!tried) break;
+      await sleep(jitter(900, 1600));
+      const changed = await yelpWaitForNewResults(prevUrl, prevFirst, 20000);
+      if (!changed) break;
+      currentPage++;
+      await sleep(jitter(900, 2000));
+      continue;
+    }
+    const tried = await yelpGotoNextPage();
+    if (!tried) break;
+    await sleep(jitter(900, 1600));
+    const changed = await yelpWaitForNewResults(prevUrl, prevFirst, 20000);
+    if (!changed) break;
+    currentPage++;
+    await sleep(jitter(1000, 2400));
+  }
+  return allResults;
+}
+
+// -------------------- YELLOW PAGES --------------------
+function ypGetCards() {
+  return Array.from(document.querySelectorAll('div.result, div.business-card'));
+}
+function ypScrapePageOnce() {
+  const out = [];
+  for (const card of ypGetCards()) {
+    const link = card.querySelector('a.business-name');
+    const name = (link?.innerText || "").trim();
+    const profileUrl = link?.href || "";
+    const phone = card.querySelector('.phones')?.innerText.trim() || "";
+    const categories = Array.from(card.querySelectorAll('.categories a'))
+      .map(a => a.innerText.trim())
+      .filter(Boolean)
+      .join(', ');
+    if (name) out.push({ name, phone, categories, profileUrl });
+  }
+  return out;
+}
+async function ypWaitForNewResults(prevUrl, prevFirst, timeoutMs = 15000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (location.href !== prevUrl) return true;
+    const firstCard = ypGetCards()[0];
+    const name = firstCard?.querySelector('a.business-name')?.innerText.trim();
+    if (name && name !== prevFirst) return true;
+    await sleep(250);
+  }
+  return false;
+}
+async function scrapeYellowPages() {
+  let allResults = [];
+  let page = 1;
+  while (true) {
+    const prevUrl = location.href;
+    const firstCard = ypGetCards()[0];
+    const prevFirst = firstCard?.querySelector('a.business-name')?.innerText.trim() || "";
+    const pageResults = ypScrapePageOnce();
+    const have = new Set(allResults.map(r => r.profileUrl));
+    for (const r of pageResults) {
+      if (!have.has(r.profileUrl)) {
+        allResults.push(r);
+        have.add(r.profileUrl);
+      }
+    }
+    chrome.runtime.sendMessage({ type: "partial", results: allResults });
+    const next = document.querySelector('a.next, a[rel="next"]');
+    if (!next) break;
+    next.click();
+    const changed = await ypWaitForNewResults(prevUrl, prevFirst);
+    if (!changed) break;
+    page++;
+    await sleep(jitter(800, 1500));
+  }
+  return allResults;
+}
+
+// -------------------- GOOGLE MAPS --------------------
+function gmGetCards() {
+  return Array.from(document.querySelectorAll('.Nv2PK'));
+}
+function gmScrapeVisible() {
+  const out = [];
+  for (const card of gmGetCards()) {
+    const name = card.querySelector('.qBF1Pd')?.innerText.trim() || '';
+    const categories = card.querySelector('.W4Efsd')?.innerText.trim() || '';
+    const profileUrl = card.querySelector('a.hfpxzc')?.href || '';
+    if (name) out.push({ name, categories, profileUrl, phone: '' });
+  }
+  return out;
+}
+async function gmScrollToEnd(container) {
+  let last = -1;
+  while (true) {
+    container.scrollTo(0, container.scrollHeight);
+    await sleep(1000);
+    if (container.scrollHeight === last) break;
+    last = container.scrollHeight;
+  }
+}
+async function scrapeGoogleMaps() {
+  const allResults = [];
+  const seen = new Set();
+  const list = document.querySelector('.m6QErb, .DxyBCb');
+  if (!list) return allResults;
+  await gmScrollToEnd(list);
+  const items = gmScrapeVisible();
+  for (const r of items) {
+    if (!seen.has(r.profileUrl)) {
+      seen.add(r.profileUrl);
+      allResults.push(r);
+    }
+  }
+  chrome.runtime.sendMessage({ type: "partial", results: allResults });
+  return allResults;
+}
+
+// -------------------- message handler --------------------
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.action === 'scrape') {
+    (async () => {
+      try {
+        let data = [];
+        if (request.site === 'yelp') {
+          data = await scrapeYelp();
+        } else if (request.site === 'yellowpages') {
+          data = await scrapeYellowPages();
+        } else if (request.site === 'googlemaps') {
+          data = await scrapeGoogleMaps();
+        }
+        sendResponse({ data });
+      } catch (e) {
+        sendResponse({ data: [] });
+      }
+    })();
+    return true;
+  }
+});

--- a/multipage_scraper/content.js
+++ b/multipage_scraper/content.js
@@ -177,16 +177,31 @@ async function scrapeYelp() {
 
 // -------------------- YELLOW PAGES --------------------
 function ypGetCards() {
-  return Array.from(document.querySelectorAll('div.result, div.business-card'));
+  return Array.from(
+    document.querySelectorAll(
+      'div.jsListing, div.listing, div.result, div.business-card, li.listing'
+    )
+  );
 }
 function ypScrapePageOnce() {
   const out = [];
   for (const card of ypGetCards()) {
-    const link = card.querySelector('a.business-name');
+    const link =
+      card.querySelector(
+        'a.business-name, a.listing__name--link, a[itemprop="url"], a[data-entityname], a[href*="/bus/"]'
+      );
     const name = (link?.innerText || "").trim();
     const profileUrl = link?.href || "";
-    const phone = card.querySelector('.phones')?.innerText.trim() || "";
-    const categories = Array.from(card.querySelectorAll('.categories a'))
+    const phone =
+      card
+        .querySelector('a[href^="tel:"], .phones, .mlr__contacts__detail, [itemprop="telephone"]')
+        ?.innerText.replace(/^Tel\s*/i, "")
+        .trim() || "";
+    const categories = Array.from(
+      card.querySelectorAll(
+        '.categories a, .listing__content__tags a, .mlr__tags .mlr__tag, [class*="category"] a'
+      )
+    )
       .map(a => a.innerText.trim())
       .filter(Boolean)
       .join(', ');
@@ -199,7 +214,12 @@ async function ypWaitForNewResults(prevUrl, prevFirst, timeoutMs = 15000) {
   while (Date.now() - start < timeoutMs) {
     if (location.href !== prevUrl) return true;
     const firstCard = ypGetCards()[0];
-    const name = firstCard?.querySelector('a.business-name')?.innerText.trim();
+    const name =
+      firstCard
+        ?.querySelector(
+          'a.business-name, a.listing__name--link, a[itemprop="url"], a[data-entityname], a[href*="/bus/"]'
+        )
+        ?.innerText.trim();
     if (name && name !== prevFirst) return true;
     await sleep(250);
   }
@@ -211,7 +231,12 @@ async function scrapeYellowPages() {
   while (true) {
     const prevUrl = location.href;
     const firstCard = ypGetCards()[0];
-    const prevFirst = firstCard?.querySelector('a.business-name')?.innerText.trim() || "";
+    const prevFirst =
+      firstCard
+        ?.querySelector(
+          'a.business-name, a.listing__name--link, a[itemprop="url"], a[data-entityname], a[href*="/bus/"]'
+        )
+        ?.innerText.trim() || "";
     const pageResults = ypScrapePageOnce();
     const have = new Set(allResults.map(r => r.profileUrl));
     for (const r of pageResults) {
@@ -221,7 +246,7 @@ async function scrapeYellowPages() {
       }
     }
     chrome.runtime.sendMessage({ type: "partial", results: allResults });
-    const next = document.querySelector('a.next, a[rel="next"]');
+    const next = document.querySelector('a.next, a[rel="next"], a[aria-label="Next"]');
     if (!next) break;
     next.click();
     const changed = await ypWaitForNewResults(prevUrl, prevFirst);
@@ -240,11 +265,43 @@ function gmScrapeVisible() {
   const out = [];
   for (const card of gmGetCards()) {
     const name = card.querySelector('.qBF1Pd')?.innerText.trim() || '';
-    const categories = card.querySelector('.W4Efsd')?.innerText.trim() || '';
     const profileUrl = card.querySelector('a.hfpxzc')?.href || '';
-    if (name) out.push({ name, categories, profileUrl, phone: '' });
+    if (name) out.push({ name, categories: '', profileUrl, phone: '' });
   }
   return out;
+}
+async function gmFetchDetails(profileUrl) {
+  await sleep(jitter(150, 450));
+  try {
+    const resp = await fetch(profileUrl, { credentials: 'include' });
+    const text = await resp.text();
+    const doc = new DOMParser().parseFromString(text, 'text/html');
+    let phone =
+      doc
+        .querySelector('a[href^="tel:"]')
+        ?.getAttribute('href')
+        ?.replace(/^tel:/, '')
+        .trim() || '';
+    let category = '';
+    const ld = doc.querySelector('script[type="application/ld+json"]');
+    if (ld) {
+      try {
+        const data = JSON.parse(ld.textContent || '{}');
+        if (!phone && data.telephone) phone = data.telephone.trim();
+        if (Array.isArray(data['@type'])) category = data['@type'].join(', ');
+        else if (typeof data['@type'] === 'string') category = data['@type'];
+        if (data.servesCuisine) {
+          const sc = Array.isArray(data.servesCuisine)
+            ? data.servesCuisine.join(', ')
+            : data.servesCuisine;
+          category = category ? `${category}, ${sc}` : sc;
+        }
+      } catch {}
+    }
+    return { phone, categories: category };
+  } catch {
+    return { phone: '', categories: '' };
+  }
 }
 async function gmScrollToEnd(container) {
   let last = -1;
@@ -262,13 +319,24 @@ async function scrapeGoogleMaps() {
   if (!list) return allResults;
   await gmScrollToEnd(list);
   const items = gmScrapeVisible();
-  for (const r of items) {
-    if (!seen.has(r.profileUrl)) {
-      seen.add(r.profileUrl);
-      allResults.push(r);
-    }
+  for (let i = 0; i < items.length; i++) {
+    const r = items[i];
+    if (seen.has(r.profileUrl)) continue;
+    seen.add(r.profileUrl);
+    const details = await gmFetchDetails(r.profileUrl);
+    r.phone = details.phone;
+    r.categories = details.categories;
+    allResults.push(r);
+    chrome.runtime.sendMessage({
+      type: 'progress',
+      current: i + 1,
+      total: items.length,
+      name: r.name,
+      page: 1
+    });
+    chrome.runtime.sendMessage({ type: 'partial', results: allResults });
+    await sleep(jitter(250, 750));
   }
-  chrome.runtime.sendMessage({ type: "partial", results: allResults });
   return allResults;
 }
 

--- a/multipage_scraper/manifest.json
+++ b/multipage_scraper/manifest.json
@@ -6,8 +6,8 @@
   "permissions": ["scripting", "activeTab", "storage"],
   "host_permissions": [
     "https://www.yelp.com/*",
-    "https://www.yellowpages.ca/*",
-    "https://*.google.com/maps/*"
+    "https://www.yellowpages.com/*",
+    "https://www.google.com/maps/*"
   ],
   "background": {
     "service_worker": "background.js"
@@ -19,8 +19,8 @@
     {
       "matches": [
         "https://www.yelp.com/*",
-        "https://www.yellowpages.ca/*",
-        "https://*.google.com/maps/*"
+        "https://www.yellowpages.com/*",
+        "https://www.google.com/maps/*"
       ],
       "js": ["content.js"]
     }

--- a/multipage_scraper/manifest.json
+++ b/multipage_scraper/manifest.json
@@ -7,7 +7,7 @@
   "host_permissions": [
     "https://www.yelp.com/*",
     "https://www.yellowpages.ca/*",
-    "https://www.google.com/maps/*"
+    "https://*.google.com/maps/*"
   ],
   "background": {
     "service_worker": "background.js"
@@ -20,7 +20,7 @@
       "matches": [
         "https://www.yelp.com/*",
         "https://www.yellowpages.ca/*",
-        "https://www.google.com/maps/*"
+        "https://*.google.com/maps/*"
       ],
       "js": ["content.js"]
     }

--- a/multipage_scraper/manifest.json
+++ b/multipage_scraper/manifest.json
@@ -1,0 +1,28 @@
+{
+  "manifest_version": 3,
+  "name": "Multipage Business Scraper",
+  "version": "1.0",
+  "description": "Scrape business info from Yelp, Yellow Pages, and Google Maps search results.",
+  "permissions": ["scripting", "activeTab", "storage"],
+  "host_permissions": [
+    "https://www.yelp.com/*",
+    "https://www.yellowpages.com/*",
+    "https://www.google.com/maps/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://www.yelp.com/*",
+        "https://www.yellowpages.com/*",
+        "https://www.google.com/maps/*"
+      ],
+      "js": ["content.js"]
+    }
+  ]
+}

--- a/multipage_scraper/manifest.json
+++ b/multipage_scraper/manifest.json
@@ -6,7 +6,7 @@
   "permissions": ["scripting", "activeTab", "storage"],
   "host_permissions": [
     "https://www.yelp.com/*",
-    "https://www.yellowpages.com/*",
+    "https://www.yellowpages.ca/*",
     "https://www.google.com/maps/*"
   ],
   "background": {
@@ -19,7 +19,7 @@
     {
       "matches": [
         "https://www.yelp.com/*",
-        "https://www.yellowpages.com/*",
+        "https://www.yellowpages.ca/*",
         "https://www.google.com/maps/*"
       ],
       "js": ["content.js"]

--- a/multipage_scraper/popup.html
+++ b/multipage_scraper/popup.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Multipage Scraper</title>
+  <style>
+    body { font-family: Arial, sans-serif; width: 300px; }
+    button { margin: 10px 0; }
+    table { width: 100%; font-size: 12px; border-collapse: collapse; }
+    th, td { border: 1px solid #ccc; padding: 3px; }
+    th { background: #eee; }
+  </style>
+</head>
+<body>
+  <h3>Multipage Scraper</h3>
+  <label>Site:
+    <select id="siteSelect">
+      <option value="yelp">Yelp</option>
+      <option value="yellowpages">Yellow Pages</option>
+      <option value="googlemaps">Google Maps</option>
+    </select>
+  </label><br/>
+  <label>Keyword: <input id="keyword" type="text" style="width:100%;" /></label><br/>
+  <label>Location: <input id="location" type="text" style="width:100%;" /></label><br/>
+  <button id="openBtn">Open Search Page</button>
+  <button id="scrapeBtn">Start Scrape</button>
+  <button id="downloadBtn" style="display:none;">Download CSV</button>
+  <div id="status"></div>
+  <table id="resultsTable" style="display:none;">
+    <thead>
+  <tr>
+    <th>Name</th>
+    <th>Phone</th>
+    <th>Categories</th>
+    <th>Website</th>
+  </tr>
+</thead>
+
+    <tbody></tbody>
+  </table>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/multipage_scraper/popup.js
+++ b/multipage_scraper/popup.js
@@ -45,7 +45,7 @@ document.getElementById("openBtn").addEventListener("click", () => {
   if (site === "yelp") {
     url = `https://www.yelp.com/search?find_desc=${keyword}&find_loc=${location}`;
   } else if (site === "yellowpages") {
-    url = `https://www.yellowpages.ca/search/si/1/${keyword}/${location}`;
+    url = `https://www.yellowpages.com/search?search_terms=${keyword}&geo_location_terms=${location}`;
   } else if (site === "googlemaps") {
     url = `https://www.google.com/maps/search/${keyword}+${location}`;
   }

--- a/multipage_scraper/popup.js
+++ b/multipage_scraper/popup.js
@@ -45,7 +45,7 @@ document.getElementById("openBtn").addEventListener("click", () => {
   if (site === "yelp") {
     url = `https://www.yelp.com/search?find_desc=${keyword}&find_loc=${location}`;
   } else if (site === "yellowpages") {
-    url = `https://www.yellowpages.com/search?search_terms=${keyword}&geo_location_terms=${location}`;
+    url = `https://www.yellowpages.ca/search/si/1/${keyword}/${location}`;
   } else if (site === "googlemaps") {
     url = `https://www.google.com/maps/search/${keyword}+${location}`;
   }

--- a/multipage_scraper/popup.js
+++ b/multipage_scraper/popup.js
@@ -1,0 +1,84 @@
+function populateTable(data) {
+  const tbody = document.querySelector("#resultsTable tbody");
+  tbody.innerHTML = "";
+  data.forEach(row => {
+    const phoneCell = row.phone ? row.phone : "<span style='color:#aaa'>(not found)</span>";
+    const categoryCell = row.categories ? row.categories : "<span style='color:#aaa'>(none)</span>";
+    const profileLink = `<a href="${row.profileUrl}" target="_blank">profile</a>`;
+    const tr = document.createElement("tr");
+    tr.innerHTML = `<td>${row.name}</td><td>${phoneCell}</td><td>${categoryCell}</td><td>${profileLink}</td>`;
+    tbody.appendChild(tr);
+  });
+  document.getElementById("resultsTable").style.display = data.length ? "" : "none";
+  document.getElementById("downloadBtn").style.display = data.length ? "" : "none";
+}
+
+function renderFromStorage() {
+  chrome.storage.local.get(["status", "results"], ({ status, results }) => {
+    if (status) document.getElementById("status").innerText = status;
+    if (results && results.length) {
+      populateTable(results);
+    }
+  });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  renderFromStorage();
+});
+
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === "local") {
+    if (changes.status) {
+      document.getElementById("status").innerText = changes.status.newValue || "";
+    }
+    if (changes.results) {
+      populateTable(changes.results.newValue || []);
+    }
+  }
+});
+
+document.getElementById("openBtn").addEventListener("click", () => {
+  const site = document.getElementById("siteSelect").value;
+  const keyword = encodeURIComponent(document.getElementById("keyword").value || "");
+  const location = encodeURIComponent(document.getElementById("location").value || "");
+  let url = "";
+  if (site === "yelp") {
+    url = `https://www.yelp.com/search?find_desc=${keyword}&find_loc=${location}`;
+  } else if (site === "yellowpages") {
+    url = `https://www.yellowpages.com/search?search_terms=${keyword}&geo_location_terms=${location}`;
+  } else if (site === "googlemaps") {
+    url = `https://www.google.com/maps/search/${keyword}+${location}`;
+  }
+  if (url) {
+    chrome.tabs.create({ url });
+  }
+});
+
+document.getElementById("scrapeBtn").addEventListener("click", async () => {
+  document.getElementById("status").innerText = "Scraping...";
+  const site = document.getElementById("siteSelect").value;
+  chrome.runtime.sendMessage({ action: "startScrape", site });
+});
+
+document.getElementById("downloadBtn").addEventListener("click", () => {
+  chrome.storage.local.get("results", ({ results }) => {
+    const data = results || [];
+    const csvRows = [
+      ["Name", "Phone", "Categories", "Profile URL"],
+      ...data.map(r => [
+        `"${r.name}"`,
+        `"${r.phone || ''}"`,
+        `"${r.categories || ''}"`,
+        `"${r.profileUrl || ''}"`
+      ])
+    ];
+    const csv = csvRows.map(row => row.join(",")).join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "scrape_results.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+});


### PR DESCRIPTION
## Summary
- add `multipage_scraper` Chrome extension supporting Yelp, Yellow Pages, and Google Maps
- allow choosing site, keyword, and location from popup and open search page
- scrape multiple pages with partial result persistence and CSV download

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c9f4bab08332b8f9a5ece17c1190