### PR TITLE
feat: add multipage scraper extension

### DIFF
--- a/multipage_scraper/background.js
+++ b/multipage_scraper/background.js
@@ -1,0 +1,43 @@
+// Background worker handling scraping and persistent storage
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === 'startScrape') {
+    // reset state
+    chrome.storage.local.set({ status: 'Scraping...', results: [] });
+    chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+      const tab = tabs[0];
+      if (!tab) {
+        chrome.storage.local.set({ status: 'Error: No active tab' });
+        return;
+      }
+      // forward scrape action to content script
+      chrome.tabs.sendMessage(tab.id, { action: message.site === 'yelp' ? 'scrapeYelp' : message.site === 'yellow' ? 'scrapeYellowPages' : 'scrapeGMaps' }, response => {
+        if (chrome.runtime.lastError || !response) {
+          chrome.storage.local.set({ status: 'Error: Could not scrape.', results: [] });
+        } else {
+          // final results already accumulated via pageResults
+          chrome.storage.local.get('results', ({ results }) => {
+            const count = results ? results.length : 0;
+            chrome.storage.local.set({ status: `Found ${count} results.` });
+          });
+        }
+      });
+    });
+    sendResponse({ started: true });
+    return true; // keep channel
+  } else if (message.type === 'progress') {
+    chrome.storage.local.set({ status: `Scraping page ${message.page} — ${message.current} of ${message.total}: ${message.name}` });
+  } else if (message.type === 'pageResults') {
+    chrome.storage.local.get('results', ({ results }) => {
+      const existing = results || [];
+      const have = new Set(existing.map(r => r.profileUrl));
+      for (const r of message.data) {
+        if (!have.has(r.profileUrl)) {
+          existing.push(r);
+          have.add(r.profileUrl);
+        }
+      }
+      chrome.storage.local.set({ results: existing });
+    });
+  }
+});

--- a/multipage_scraper/gmaps.js
+++ b/multipage_scraper/gmaps.js
@@ -1,0 +1,91 @@
+// === gmaps.js (scrape all result pages) ===
+
+const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+const jitter = (min, max) => min + Math.floor(Math.random() * (max - min + 1));
+
+function getCards() {
+  return Array.from(document.querySelectorAll('div.Nv2PK')); // each result card
+}
+
+function firstResultName() {
+  const first = getCards()[0];
+  const link = first?.querySelector('a.hfpxzc');
+  return (link?.textContent || '').trim();
+}
+
+async function waitForNewResults(prevUrl, prevFirst, timeoutMs = 20000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const nowFirst = firstResultName();
+    if (nowFirst && nowFirst !== prevFirst) return true;
+    await sleep(250);
+  }
+  return false;
+}
+
+async function getPhoneNumber(profileUrl) {
+  await sleep(jitter(200, 600));
+  try {
+    const res = await fetch(profileUrl, { credentials: 'include' });
+    const text = await res.text();
+    const doc = new DOMParser().parseFromString(text, 'text/html');
+    const tel = doc.querySelector('a[href^="tel:"]')?.getAttribute('href')?.replace(/^tel:/,'').trim() || '';
+    return tel;
+  } catch {
+    return '';
+  }
+}
+
+function scrapePageOnce() {
+  const out = [];
+  for (const card of getCards()) {
+    const link = card.querySelector('a.hfpxzc');
+    const href = link?.href || '';
+    const name = (link?.textContent || '').trim();
+    if (name) out.push({ name, profileUrl: href, categories: '' });
+  }
+  return out;
+}
+
+function findNextButton() {
+  return document.querySelector('button[aria-label=" Next page "], button[aria-label="Next page"]');
+}
+
+async function gotoNextPage() {
+  const btn = findNextButton();
+  if (!btn) return false;
+  btn.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  await sleep(jitter(350,900));
+  btn.click();
+  return true;
+}
+
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.action === 'scrapeGMaps') {
+    (async () => {
+      let allResults = [];
+      let currentPage = 1;
+      while (true) {
+        const prevFirst = firstResultName();
+        const pageResults = scrapePageOnce();
+        for (let i=0;i<pageResults.length;i++) {
+          const biz = pageResults[i];
+          biz.phone = await getPhoneNumber(biz.profileUrl);
+          chrome.runtime.sendMessage({ type: 'progress', current: i+1, total: pageResults.length, name: biz.name, page: currentPage });
+          await sleep(jitter(260,780));
+        }
+        chrome.runtime.sendMessage({ type: 'pageResults', data: pageResults });
+        allResults.push(...pageResults);
+        const moved = await gotoNextPage();
+        if (!moved) break;
+        await sleep(jitter(900,1600));
+        const changed = await waitForNewResults('', prevFirst, 20000);
+        if (!changed) break;
+        currentPage++;
+        await sleep(jitter(900,2000));
+      }
+      sendResponse({ data: allResults });
+    })();
+    return true;
+  }
+});

--- a/multipage_scraper/manifest.json
+++ b/multipage_scraper/manifest.json
@@ -1,0 +1,33 @@
+{
+  "manifest_version": 3,
+  "name": "Multipage Business Scraper",
+  "version": "1.0",
+  "description": "Scrape business data from Yelp, YellowPages, and Google Maps.",
+  "permissions": ["scripting", "activeTab", "storage"],
+  "host_permissions": [
+    "https://www.yelp.com/search*",
+    "https://www.yellowpages.ca/search*",
+    "https://www.google.com/maps/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://www.yelp.com/search*"],
+      "js": ["yelp.js"]
+    },
+    {
+      "matches": ["https://www.yellowpages.ca/search*"],
+      "js": ["yellowpages.js"]
+    },
+    {
+      "matches": ["https://www.google.com/maps/*"],
+      "js": ["gmaps.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/multipage_scraper/popup.html
+++ b/multipage_scraper/popup.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Multipage Scraper</title>
+  <style>
+    body { font-family: Arial, sans-serif; width: 300px; }
+    button { margin: 10px 0; }
+    table { width: 100%; font-size: 12px; border-collapse: collapse; }
+    th, td { border: 1px solid #ccc; padding: 3px; }
+    th { background: #eee; }
+  </style>
+</head>
+<body>
+  <h3>Multipage Scraper</h3>
+  <label>Website:
+    <select id="site">
+      <option value="yelp">Yelp</option>
+      <option value="yellow">YellowPages.ca</option>
+      <option value="gmaps">Google Maps</option>
+    </select>
+  </label>
+  <button id="openBtn">Open Search Page</button>
+  <button id="scrapeBtn">Start Scrape</button>
+  <button id="downloadBtn" style="display:none;">Download CSV</button>
+  <div id="status"></div>
+  <table id="resultsTable" style="display:none;">
+    <thead>
+  <tr>
+    <th>Name</th>
+    <th>Phone</th>
+    <th>Categories</th>
+    <th>Website</th>
+  </tr>
+</thead>
+
+    <tbody></tbody>
+  </table>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/multipage_scraper/popup.js
+++ b/multipage_scraper/popup.js
@@ -1,0 +1,78 @@
+function populateTable(data) {
+  const tbody = document.querySelector("#resultsTable tbody");
+  tbody.innerHTML = "";
+  data.forEach(row => {
+    const phoneCell = row.phone ? row.phone : "<span style='color:#aaa'>(not found)</span>";
+    const categoryCell = row.categories ? row.categories : "<span style='color:#aaa'>(none)</span>";
+    const profileLink = `<a href="${row.profileUrl}" target="_blank">profile</a>`;
+    const tr = document.createElement("tr");
+    tr.innerHTML = `<td>${row.name}</td><td>${phoneCell}</td><td>${categoryCell}</td><td>${profileLink}</td>`;
+    tbody.appendChild(tr);
+  });
+  document.getElementById("resultsTable").style.display = data.length ? "" : "none";
+  document.getElementById("downloadBtn").style.display = data.length ? "" : "none";
+}
+
+function renderFromStorage() {
+  chrome.storage.local.get(["status", "results"], ({ status, results }) => {
+    if (status) document.getElementById("status").innerText = status;
+    if (results && results.length) {
+      populateTable(results);
+    }
+  });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  renderFromStorage();
+});
+
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === "local") {
+    if (changes.status) {
+      document.getElementById("status").innerText = changes.status.newValue || "";
+    }
+    if (changes.results) {
+      populateTable(changes.results.newValue || []);
+    }
+  }
+});
+
+document.getElementById("openBtn").addEventListener("click", () => {
+  const site = document.getElementById("site").value;
+  const url =
+    site === "yelp"
+      ? "https://www.yelp.com/search"
+      : site === "yellow"
+      ? "https://www.yellowpages.ca/"
+      : "https://www.google.com/maps";
+  chrome.tabs.create({ url });
+});
+
+document.getElementById("scrapeBtn").addEventListener("click", async () => {
+  document.getElementById("status").innerText = "Scraping...";
+  const site = document.getElementById("site").value;
+  chrome.runtime.sendMessage({ action: "startScrape", site });
+});
+
+document.getElementById("downloadBtn").addEventListener("click", () => {
+  chrome.storage.local.get("results", ({ results }) => {
+    const data = results || [];
+    const csvRows = [
+      ["Name", "Phone", "Categories", "Profile URL"],
+      ...data.map(r => [
+        `"${r.name}"`,
+        `"${r.phone || ''}"`,
+        `"${r.categories || ''}"`,
+        `"${r.profileUrl}"`
+      ])
+    ];
+    const csv = csvRows.map(row => row.join(",")).join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "results.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+});

--- a/multipage_scraper/yellowpages.js
+++ b/multipage_scraper/yellowpages.js
@@ -1,0 +1,92 @@
+// === yellowpages.js (scrape all result pages) ===
+
+const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+const jitter = (min, max) => min + Math.floor(Math.random() * (max - min + 1));
+
+function getCards() {
+  return Array.from(document.querySelectorAll('div.result, div.listing')); // basic selector
+}
+
+function firstResultName() {
+  const first = getCards()[0];
+  const link = first?.querySelector('a[href*="/bus/"]');
+  return (link?.textContent || '').trim();
+}
+
+async function waitForNewResults(prevUrl, prevFirst, timeoutMs = 20000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (location.href !== prevUrl) return true;
+    const nowFirst = firstResultName();
+    if (nowFirst && nowFirst !== prevFirst) return true;
+    await sleep(250);
+  }
+  return false;
+}
+
+async function getPhoneNumber(profileUrl) {
+  await sleep(jitter(120, 420));
+  try {
+    const res = await fetch(profileUrl, { credentials: 'include' });
+    const text = await res.text();
+    const doc = new DOMParser().parseFromString(text, 'text/html');
+    const tel = doc.querySelector('a[href^="tel:"]')?.getAttribute('href')?.replace(/^tel:/,'').trim()
+      || doc.querySelector('span[itemprop="telephone"]')?.textContent.trim() || '';
+    return tel;
+  } catch {
+    return '';
+  }
+}
+
+function scrapePageOnce() {
+  const out = [];
+  for (const card of getCards()) {
+    const linkEl = card.querySelector('a[href*="/bus/"]');
+    const href = linkEl?.href || '';
+    const name = (linkEl?.textContent || '').trim();
+    const categories = Array.from(card.querySelectorAll('.listing__categories a, .categories a'))
+      .map(a => a.textContent.trim()).filter(Boolean).join(', ');
+    if (name) out.push({ name, profileUrl: href, categories });
+  }
+  return out;
+}
+
+async function gotoNextPage() {
+  const a = document.querySelector('a[rel="next"], a.pagination__next, a.next');
+  if (!a) return false;
+  a.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  await sleep(jitter(350, 900));
+  a.click();
+  return true;
+}
+
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.action === 'scrapeYellowPages') {
+    (async () => {
+      let allResults = [];
+      let currentPage = 1;
+      while (true) {
+        const prevUrl = location.href;
+        const prevFirst = firstResultName();
+        const pageResults = scrapePageOnce();
+        for (let i=0;i<pageResults.length;i++) {
+          const biz = pageResults[i];
+          biz.phone = await getPhoneNumber(biz.profileUrl);
+          chrome.runtime.sendMessage({ type: 'progress', current: i+1, total: pageResults.length, name: biz.name, page: currentPage });
+          await sleep(jitter(260,780));
+        }
+        chrome.runtime.sendMessage({ type: 'pageResults', data: pageResults });
+        allResults.push(...pageResults);
+        const moved = await gotoNextPage();
+        if (!moved) break;
+        await sleep(jitter(900,1600));
+        const changed = await waitForNewResults(prevUrl, prevFirst, 20000);
+        if (!changed) break;
+        currentPage++;
+        await sleep(jitter(900,2000));
+      }
+      sendResponse({ data: allResults });
+    })();
+    return true;
+  }
+});

--- a/multipage_scraper/yelp.js
+++ b/multipage_scraper/yelp.js
@@ -1,0 +1,230 @@
+// === yelp.js (robust "all pages" + human-like) ===
+
+// ---- helpers ----
+const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+const jitter = (min, max) => min + Math.floor(Math.random() * (max - min + 1));
+
+function getCards() {
+  return Array.from(document.querySelectorAll('div[data-testid="scrollable-photos-card"]'));
+}
+function firstResultName() {
+  const firstCard = getCards()[0];
+  const link = firstCard?.querySelector('div[data-traffic-crawl-id="SearchResultBizName"] a');
+  return (link?.textContent || "").trim();
+}
+async function waitForNewResults(prevUrl, prevFirst, timeoutMs = 20000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (location.href !== prevUrl) return true;
+    const nowFirst = firstResultName();
+    if (nowFirst && nowFirst !== prevFirst) return true;
+    await sleep(250);
+  }
+  return false;
+}
+
+function findNextButton() {
+  // Buttons
+  let btn = document.querySelector('button[aria-label="Next page"]');
+  if (btn) return btn;
+  const candidates = Array.from(document.querySelectorAll('button, a[role="button"]'));
+  btn = candidates.find(b => {
+    const t = (b.textContent || "").trim().toLowerCase();
+    return t === "next" || t === "next page";
+  });
+  return btn || null;
+}
+function findNextAnchor() {
+  return (
+    document.querySelector('a[rel="next"]') ||
+    document.querySelector('a[aria-label="Next"], a[aria-label="Next page"]') ||
+    null
+  );
+}
+
+// Synthesize a "next" URL using start= param as a last resort
+function synthesizeNextUrl() {
+  try {
+    const url = new URL(location.href);
+    const currentStart = parseInt(url.searchParams.get("start") || "0", 10) || 0;
+    // Use cards on current page; default to 10 if ambiguous
+    const perPage = Math.max(getCards().length, 10);
+    const nextStart = currentStart + perPage;
+    url.searchParams.set("start", String(nextStart));
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+async function getPhoneNumber(profileUrl) {
+  // tiny delay per request to avoid uniform cadence
+  await sleep(jitter(120, 420));
+  try {
+    const response = await fetch(profileUrl, { credentials: "include" });
+    const text = await response.text();
+    const doc = new DOMParser().parseFromString(text, "text/html");
+
+    // Primary: tel: link
+    let phone =
+      doc.querySelector('a[href^="tel:"]')?.getAttribute("href")?.replace(/^tel:/, "").trim() || "";
+
+    // Fallback: your older selector
+    if (!phone) {
+      phone =
+        doc
+          .querySelector('span[aria-label="Business phone number"]')
+          ?.parentElement?.nextElementSibling?.querySelector('p[data-font-weight="semibold"]')
+          ?.innerText.trim() || "";
+    }
+
+    return phone;
+  } catch {
+    return "";
+  }
+}
+
+function scrapePageOnce() {
+  const out = [];
+  for (const card of getCards()) {
+    const bizLink = card.querySelector('div[data-traffic-crawl-id="SearchResultBizName"] a');
+    const href = bizLink?.getAttribute("href") || "";
+    if (!href.startsWith("/biz/")) continue; // skip ads/sponsored
+
+    const name = (bizLink?.innerText || "").trim();
+    const profileUrl = `https://www.yelp.com${href}`;
+
+    // categories
+    let categories = "";
+    const categoriesDiv = card.querySelector('div[data-testid="serp-ia-categories"]');
+    if (categoriesDiv) {
+      const categoryList = Array.from(categoriesDiv.querySelectorAll('a > button > span'))
+        .map(s => s.innerText.trim())
+        .filter(Boolean);
+      categories = categoryList.join(", ");
+    }
+    if (name) out.push({ name, profileUrl, categories });
+  }
+  return out;
+}
+
+// Attempt to go to the next page using multiple strategies
+async function gotoNextPage() {
+  // 1) Try button click
+  const btn = findNextButton();
+  if (btn) {
+    btn.scrollIntoView({ behavior: "smooth", block: "center" });
+    await sleep(jitter(350, 900));
+    btn.click();
+    return true;
+  }
+  // 2) Try anchor click
+  const a = findNextAnchor();
+  if (a) {
+    a.scrollIntoView({ behavior: "smooth", block: "center" });
+    await sleep(jitter(350, 900));
+    a.click();
+    return true;
+  }
+  // 3) Synthesize URL with start= param
+  const nextUrl = synthesizeNextUrl();
+  if (nextUrl) {
+    window.scrollTo({ top: 0, behavior: "instant" }); // optional
+    await sleep(jitter(200, 500));
+    location.href = nextUrl;
+    return true;
+  }
+  // No way to go next
+  return false;
+}
+
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.action === "scrapeYelp") {
+    (async () => {
+      const hardPageLimit = Number.isFinite(request.numPages) && request.numPages > 0 ? request.numPages : 999; // "all pages"
+      let currentPage = 1;
+
+      let allResults = [];
+      const seenThisSession = new Set(); // to guard against accidental repeats/loops
+      let keepGoing = true;
+      let stagnantStrike = 0; // if we see the same page twice, increment; stop after a couple
+
+      while (keepGoing && currentPage <= hardPageLimit) {
+        const prevUrl = location.href;
+        const prevFirst = firstResultName();
+
+        // ---- scrape current page ----
+        const pageResults = scrapePageOnce();
+
+        // Detect if we somehow re-landed on an identical page (no organic cards)
+        const pageKey = `${prevUrl}|${pageResults.map(r => r.profileUrl).join(",")}`;
+        if (seenThisSession.has(pageKey)) {
+          stagnantStrike++;
+        } else {
+          stagnantStrike = 0;
+          seenThisSession.add(pageKey);
+        }
+
+        // fetch phones with small per-item jitters
+        for (let i = 0; i < pageResults.length; i++) {
+          const biz = pageResults[i];
+          biz.phone = await getPhoneNumber(biz.profileUrl);
+
+          chrome.runtime.sendMessage({
+            type: "progress",
+            current: i + 1,
+            total: pageResults.length,
+            name: biz.name,
+            page: currentPage
+          });
+
+          await sleep(jitter(260, 780));
+        }
+
+        // store partial results so far
+        chrome.runtime.sendMessage({ type: "pageResults", data: pageResults });
+
+        // merge (dedupe by profileUrl, just in case)
+        const before = allResults.length;
+        const have = new Set(allResults.map(r => r.profileUrl));
+        for (const r of pageResults) {
+          if (!have.has(r.profileUrl)) {
+            allResults.push(r);
+            have.add(r.profileUrl);
+          }
+        }
+        const added = allResults.length - before;
+
+        // ---- decide if we should continue ----
+        // If we hit a repeated page twice or added nothing, we’re likely at the end or looping.
+        if (added === 0 || stagnantStrike >= 2) {
+          // Try one last time to navigate next; if we fail or page doesn't change, we stop
+          const tried = await gotoNextPage();
+          if (!tried) break;
+          await sleep(jitter(900, 1600));
+          const changed = await waitForNewResults(prevUrl, prevFirst, 20000);
+          if (!changed) break;
+          currentPage++;
+          await sleep(jitter(900, 2000));
+          continue;
+        }
+
+        // normal next
+        if (currentPage >= hardPageLimit) break;
+        const tried = await gotoNextPage();
+        if (!tried) break; // no more pages available
+
+        // wait for real change
+        await sleep(jitter(900, 1600));
+        const changed = await waitForNewResults(prevUrl, prevFirst, 20000);
+        if (!changed) break;
+
+        currentPage++;
+        await sleep(jitter(1000, 2400));
+      }
+
+      sendResponse({ data: allResults });
+    })();
+    return true; // async
+  }
+});


### PR DESCRIPTION
## Summary
- add multipage scraper extension supporting Yelp, YellowPages, and Google Maps
- allow selecting site, opening search page, and scraping all results with partial-save progress

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68a9dcf4579083328def13866bccf901